### PR TITLE
feat(dirs): adds full dir path tree and list

### DIFF
--- a/etc/hub.api.md
+++ b/etc/hub.api.md
@@ -87,8 +87,7 @@ export class Buckets extends BucketsGrpcClient {
     links(key: string): Promise<LinksReply.AsObject>;
     list(): Promise<Root.AsObject[]>;
     listIpfsPath(path: string): Promise<ListPathItem.AsObject | undefined>;
-    listPath(key: string, path: string): Promise<ListPathReply.AsObject>;
-    listPathRecursive(key: string, path: string): Promise<ListPathRecursive>;
+    listPath(key: string, path: string, recursive?: boolean): Promise<ListPathReply.AsObject>;
     listPathRecursiveFlat(key: string, path: string, dirs?: boolean): Promise<ListPathRecursiveFlat>;
     open(name: string, threadName?: string, isPrivate?: boolean, threadID?: string): Promise<Root.AsObject | undefined>;
     pullIpfsPath(path: string, opts?: {
@@ -174,6 +173,9 @@ export function bucketsRemovePath(api: BucketsGrpcClient, key: string, path: str
 
 // @public
 export function bucketsRoot(api: BucketsGrpcClient, key: string, ctx?: ContextInterface): Promise<Root.AsObject | undefined>;
+
+// @public
+export function bufToArray(chunk: Buffer, size?: number): Buffer[];
 
 // @public
 export class Client {
@@ -339,10 +341,16 @@ export { ListIpfsPathReply }
 export { ListPathItem }
 
 // @public (undocumented)
-export type ListPathRecursive = ReturnType<typeof utilListPathRecursive>;
+export type ListPathRecursive = ReturnType<typeof listPathRecursive>;
+
+// @public
+export function listPathRecursive(grpc: BucketsGrpcClient, bucketKey: string, path: string): Promise<ListPathReply.AsObject>;
 
 // @public (undocumented)
-export type ListPathRecursiveFlat = ReturnType<typeof utilListPathRecursiveFlat>;
+export type ListPathRecursiveFlat = ReturnType<typeof listPathRecursiveFlat>;
+
+// @public
+export function listPathRecursiveFlat(grpc: BucketsGrpcClient, bucketKey: string, path: string, dirs?: boolean): Promise<string[]>;
 
 export { ListPathReply }
 
@@ -441,15 +449,6 @@ export type UserAuth = {
     msg: string;
     token?: string;
 };
-
-// @public
-export function utilBufToArray(chunk: Buffer, size?: number): Buffer[];
-
-// @public
-export function utilListPathRecursive(grpc: BucketsGrpcClient, bucketKey: string, path: string): Promise<ListPathItem.AsObject | undefined>;
-
-// @public
-export function utilListPathRecursiveFlat(grpc: BucketsGrpcClient, bucketKey: string, path: string, dirs?: boolean): Promise<string[]>;
 
 // @public
 export enum Variant {

--- a/etc/hub.api.md
+++ b/etc/hub.api.md
@@ -81,15 +81,23 @@ export class Buckets extends BucketsGrpcClient {
         id: string | undefined;
         msg: string;
     }, err?: Error) => void): Promise<() => void>;
+    getOrInitBucket(name: string, threadName?: string, isPrivate?: boolean, threadID?: string): Promise<{
+        root?: Root.AsObject;
+        threadID?: string;
+    }>;
     getToken(identity: Identity): Promise<string>;
     getTokenChallenge(publicKey: string, callback: (challenge: Uint8Array) => Uint8Array | Promise<Uint8Array>): Promise<string>;
     init(name: string, isPrivate?: boolean): Promise<InitReply.AsObject>;
     links(key: string): Promise<LinksReply.AsObject>;
     list(): Promise<Root.AsObject[]>;
     listIpfsPath(path: string): Promise<ListPathItem.AsObject | undefined>;
-    listPath(key: string, path: string, recursive?: boolean): Promise<ListPathReply.AsObject>;
-    listPathRecursiveFlat(key: string, path: string, dirs?: boolean): Promise<ListPathRecursiveFlat>;
-    open(name: string, threadName?: string, isPrivate?: boolean, threadID?: string): Promise<Root.AsObject | undefined>;
+    listPath(key: string, path: string, depth?: number): Promise<ListPathReply.AsObject>;
+    listPathRecursiveFlat(key: string, path: string, dirs?: boolean, depth?: number): Promise<ListPathRecursiveFlat>;
+    // @deprecated
+    open(name: string, threadName?: string, isPrivate?: boolean, threadID?: string): Promise<{
+        root?: Root.AsObject;
+        threadID?: string;
+    }>;
     pullIpfsPath(path: string, opts?: {
         progress?: (num?: number) => void;
     }): AsyncIterableIterator<Uint8Array>;
@@ -344,13 +352,13 @@ export { ListPathItem }
 export type ListPathRecursive = ReturnType<typeof listPathRecursive>;
 
 // @public
-export function listPathRecursive(grpc: BucketsGrpcClient, bucketKey: string, path: string): Promise<ListPathReply.AsObject>;
+export function listPathRecursive(grpc: BucketsGrpcClient, bucketKey: string, path: string, depth: number, currentDepth?: number): Promise<ListPathReply.AsObject>;
 
 // @public (undocumented)
 export type ListPathRecursiveFlat = ReturnType<typeof listPathRecursiveFlat>;
 
 // @public
-export function listPathRecursiveFlat(grpc: BucketsGrpcClient, bucketKey: string, path: string, dirs?: boolean): Promise<string[]>;
+export function listPathRecursiveFlat(grpc: BucketsGrpcClient, bucketKey: string, path: string, dirs: boolean, depth: number): Promise<string[]>;
 
 export { ListPathReply }
 

--- a/etc/hub.api.md
+++ b/etc/hub.api.md
@@ -81,7 +81,7 @@ export class Buckets extends BucketsGrpcClient {
         id: string | undefined;
         msg: string;
     }, err?: Error) => void): Promise<() => void>;
-    getOrInitBucket(name: string, threadName?: string, isPrivate?: boolean, threadID?: string): Promise<{
+    getOrInit(name: string, threadName?: string, isPrivate?: boolean, threadID?: string): Promise<{
         root?: Root.AsObject;
         threadID?: string;
     }>;

--- a/etc/hub.api.md
+++ b/etc/hub.api.md
@@ -92,7 +92,7 @@ export class Buckets extends BucketsGrpcClient {
     list(): Promise<Root.AsObject[]>;
     listIpfsPath(path: string): Promise<ListPathItem.AsObject | undefined>;
     listPath(key: string, path: string, depth?: number): Promise<ListPathReply.AsObject>;
-    listPathRecursiveFlat(key: string, path: string, dirs?: boolean, depth?: number): Promise<ListPathRecursiveFlat>;
+    listPathFlat(key: string, path: string, dirs?: boolean, depth?: number): Promise<ListPathFlat>;
     // @deprecated
     open(name: string, threadName?: string, isPrivate?: boolean, threadID?: string): Promise<{
         root?: Root.AsObject;
@@ -346,6 +346,12 @@ export { LinksReply }
 
 export { ListIpfsPathReply }
 
+// @public (undocumented)
+export type ListPathFlat = ReturnType<typeof listPathFlat>;
+
+// @public
+export function listPathFlat(grpc: BucketsGrpcClient, bucketKey: string, path: string, dirs: boolean, depth: number): Promise<string[]>;
+
 export { ListPathItem }
 
 // @public (undocumented)
@@ -353,12 +359,6 @@ export type ListPathRecursive = ReturnType<typeof listPathRecursive>;
 
 // @public
 export function listPathRecursive(grpc: BucketsGrpcClient, bucketKey: string, path: string, depth: number, currentDepth?: number): Promise<ListPathReply.AsObject>;
-
-// @public (undocumented)
-export type ListPathRecursiveFlat = ReturnType<typeof listPathRecursiveFlat>;
-
-// @public
-export function listPathRecursiveFlat(grpc: BucketsGrpcClient, bucketKey: string, path: string, dirs: boolean, depth: number): Promise<string[]>;
 
 export { ListPathReply }
 

--- a/etc/hub.api.md
+++ b/etc/hub.api.md
@@ -89,7 +89,7 @@ export class Buckets extends BucketsGrpcClient {
     listIpfsPath(path: string): Promise<ListPathItem.AsObject | undefined>;
     listPath(key: string, path: string): Promise<ListPathReply.AsObject>;
     listPathRecursive(key: string, path: string): Promise<ListPathRecursive>;
-    listPathRecursiveFlat(key: string, path: string): Promise<ListPathRecursiveFlat>;
+    listPathRecursiveFlat(key: string, path: string, dirs?: boolean): Promise<ListPathRecursiveFlat>;
     open(name: string, threadName?: string, isPrivate?: boolean, threadID?: string): Promise<Root.AsObject | undefined>;
     pullIpfsPath(path: string, opts?: {
         progress?: (num?: number) => void;
@@ -449,7 +449,7 @@ export function utilBufToArray(chunk: Buffer, size?: number): Buffer[];
 export function utilListPathRecursive(grpc: BucketsGrpcClient, bucketKey: string, path: string): Promise<ListPathItem.AsObject | undefined>;
 
 // @public
-export function utilListPathRecursiveFlat(grpc: BucketsGrpcClient, bucketKey: string, path: string): Promise<string[]>;
+export function utilListPathRecursiveFlat(grpc: BucketsGrpcClient, bucketKey: string, path: string, dirs?: boolean): Promise<string[]>;
 
 // @public
 export enum Variant {

--- a/etc/hub.api.md
+++ b/etc/hub.api.md
@@ -183,7 +183,7 @@ export function bucketsRemovePath(api: BucketsGrpcClient, key: string, path: str
 export function bucketsRoot(api: BucketsGrpcClient, key: string, ctx?: ContextInterface): Promise<Root.AsObject | undefined>;
 
 // @public
-export function bufToArray(chunk: Buffer, size?: number): Buffer[];
+export function bytesToArray(chunk: Uint8Array, size?: number): Uint8Array[];
 
 // @public
 export class Client {

--- a/etc/hub.api.md
+++ b/etc/hub.api.md
@@ -88,6 +88,8 @@ export class Buckets extends BucketsGrpcClient {
     list(): Promise<Root.AsObject[]>;
     listIpfsPath(path: string): Promise<ListPathItem.AsObject | undefined>;
     listPath(key: string, path: string): Promise<ListPathReply.AsObject>;
+    listPathRecursive(key: string, path: string): Promise<ListPathRecursive>;
+    listPathRecursiveFlat(key: string, path: string): Promise<ListPathRecursiveFlat>;
     open(name: string, threadName?: string, isPrivate?: boolean, threadID?: string): Promise<Root.AsObject | undefined>;
     pullIpfsPath(path: string, opts?: {
         progress?: (num?: number) => void;
@@ -336,6 +338,12 @@ export { ListIpfsPathReply }
 
 export { ListPathItem }
 
+// @public (undocumented)
+export type ListPathRecursive = ReturnType<typeof utilListPathRecursive>;
+
+// @public (undocumented)
+export type ListPathRecursiveFlat = ReturnType<typeof utilListPathRecursiveFlat>;
+
 export { ListPathReply }
 
 export { ListReply }
@@ -433,6 +441,15 @@ export type UserAuth = {
     msg: string;
     token?: string;
 };
+
+// @public
+export function utilBufToArray(chunk: Buffer, size?: number): Buffer[];
+
+// @public
+export function utilListPathRecursive(grpc: BucketsGrpcClient, bucketKey: string, path: string): Promise<ListPathItem.AsObject | undefined>;
+
+// @public
+export function utilListPathRecursiveFlat(grpc: BucketsGrpcClient, bucketKey: string, path: string): Promise<string[]>;
 
 // @public
 export enum Variant {

--- a/packages/buckets/src/api/index.ts
+++ b/packages/buckets/src/api/index.ts
@@ -239,6 +239,7 @@ export async function bucketsListIpfsPath(
  * @param opts Options to control response stream. Currently only supports a progress function.
  * @remarks
  * This will return the resolved path and the bucket's new root path.
+ * Data must be broken into <4mb chunks. See bufToArray() for help.
  * @example
  * Push a file to the root of a bucket
  * ```tyepscript

--- a/packages/buckets/src/buckets.spec.ts
+++ b/packages/buckets/src/buckets.spec.ts
@@ -136,6 +136,25 @@ describe('Buckets...', () => {
     rep = await client.listPath(rootKey, 'dir1/file1.jpg')
     expect(rep.item?.path.endsWith('file1.jpg')).to.be.true
     expect(rep.item?.isdir).to.be.false
+
+    // Recursive dir
+    const item = await client.listPathRecursive(rootKey, '')
+    expect(item?.isdir).to.be.true
+    expect(item?.itemsList).to.have.length(3)
+
+    // Recursive dir
+    // [
+    //   'mybuck',
+    //   'mybuck/.textileseed',
+    //   'mybuck/dir1',
+    //   'mybuck/dir1/file1.jpg',
+    //   'mybuck/path',
+    //   'mybuck/path/to',
+    //   'mybuck/path/to/file2.jpg'
+    // ]
+    const list = await client.listPathRecursiveFlat(rootKey, '')
+    console.log(list)
+    expect(list).to.have.length(7)
   })
 
   it('should pull files by path and write to file on node', async function () {

--- a/packages/buckets/src/buckets.spec.ts
+++ b/packages/buckets/src/buckets.spec.ts
@@ -25,7 +25,7 @@ describe('Buckets...', () => {
   })
 
   it('should open a bucket by name without thread info', async () => {
-    const root = await client.open('initbuck')
+    const { root, threadID } = await client.getOrInitBucket('initbuck')
     expect(root).to.have.ownProperty('key')
     expect(root).to.have.ownProperty('path')
     expect(root).to.have.ownProperty('createdat')
@@ -138,7 +138,7 @@ describe('Buckets...', () => {
     expect(rep.item?.isdir).to.be.false
 
     // Recursive dir
-    rep = await client.listPath(rootKey, '', true)
+    rep = await client.listPath(rootKey, '', 3)
     expect(rep.item?.isdir).to.be.true
     expect(rep.item?.itemsList).to.have.length(3)
 

--- a/packages/buckets/src/buckets.spec.ts
+++ b/packages/buckets/src/buckets.spec.ts
@@ -152,9 +152,13 @@ describe('Buckets...', () => {
     //   'mybuck/path/to',
     //   'mybuck/path/to/file2.jpg'
     // ]
-    const list = await client.listPathRecursiveFlat(rootKey, '')
+    let list = await client.listPathRecursiveFlat(rootKey, '')
     console.log(list)
     expect(list).to.have.length(7)
+
+    list = await client.listPathRecursiveFlat(rootKey, '', false)
+    console.log(list)
+    expect(list).to.have.length(3)
   })
 
   it('should pull files by path and write to file on node', async function () {

--- a/packages/buckets/src/buckets.spec.ts
+++ b/packages/buckets/src/buckets.spec.ts
@@ -25,7 +25,7 @@ describe('Buckets...', () => {
   })
 
   it('should open a bucket by name without thread info', async () => {
-    const { root, threadID } = await client.getOrInitBucket('initbuck')
+    const { root, threadID } = await client.getOrInit('initbuck')
     expect(threadID).to.not.be.undefined
     expect(root).to.have.ownProperty('key')
     expect(root).to.have.ownProperty('path')

--- a/packages/buckets/src/buckets.spec.ts
+++ b/packages/buckets/src/buckets.spec.ts
@@ -138,9 +138,9 @@ describe('Buckets...', () => {
     expect(rep.item?.isdir).to.be.false
 
     // Recursive dir
-    const item = await client.listPathRecursive(rootKey, '')
-    expect(item?.isdir).to.be.true
-    expect(item?.itemsList).to.have.length(3)
+    rep = await client.listPath(rootKey, '', true)
+    expect(rep.item?.isdir).to.be.true
+    expect(rep.item?.itemsList).to.have.length(3)
 
     // Recursive dir
     // [
@@ -153,11 +153,9 @@ describe('Buckets...', () => {
     //   'mybuck/path/to/file2.jpg'
     // ]
     let list = await client.listPathRecursiveFlat(rootKey, '')
-    console.log(list)
     expect(list).to.have.length(7)
 
     list = await client.listPathRecursiveFlat(rootKey, '', false)
-    console.log(list)
     expect(list).to.have.length(3)
   })
 

--- a/packages/buckets/src/buckets.spec.ts
+++ b/packages/buckets/src/buckets.spec.ts
@@ -26,6 +26,7 @@ describe('Buckets...', () => {
 
   it('should open a bucket by name without thread info', async () => {
     const { root, threadID } = await client.getOrInitBucket('initbuck')
+    expect(threadID).to.not.be.undefined
     expect(root).to.have.ownProperty('key')
     expect(root).to.have.ownProperty('path')
     expect(root).to.have.ownProperty('createdat')
@@ -152,10 +153,10 @@ describe('Buckets...', () => {
     //   'mybuck/path/to',
     //   'mybuck/path/to/file2.jpg'
     // ]
-    let list = await client.listPathRecursiveFlat(rootKey, '')
+    let list = await client.listPathFlat(rootKey, '')
     expect(list).to.have.length(7)
 
-    list = await client.listPathRecursiveFlat(rootKey, '', false)
+    list = await client.listPathFlat(rootKey, '', false)
     expect(list).to.have.length(3)
   })
 

--- a/packages/buckets/src/buckets.ts
+++ b/packages/buckets/src/buckets.ts
@@ -32,7 +32,7 @@ import {
   bucketsInit,
   PushPathResult,
 } from './api'
-import { listPathRecursive, listPathRecursiveFlat, ListPathRecursive, ListPathRecursiveFlat } from './utils'
+import { listPathRecursive, listPathFlat, ListPathRecursive, ListPathFlat } from './utils'
 
 const logger = log.getLogger('buckets')
 
@@ -302,7 +302,7 @@ export class Buckets extends BucketsGrpcClient {
    * import { Buckets } from '@textile/hub'
    *
    * async function printPaths(buckets: Buckets, bucketKey: string) {
-   *   const list = await buckets.listPathRecursiveFlat(bucketKey, '')
+   *   const list = await buckets.listPathFlat(bucketKey, '')
    *   console.log(list)
    * }
    * // [
@@ -316,9 +316,9 @@ export class Buckets extends BucketsGrpcClient {
    * // ]
    * ```
    */
-  async listPathRecursiveFlat(key: string, path: string, dirs = true, depth = 5): Promise<ListPathRecursiveFlat> {
+  async listPathFlat(key: string, path: string, dirs = true, depth = 5): Promise<ListPathFlat> {
     logger.debug('list path recursive request')
-    return await listPathRecursiveFlat(this, key, path, dirs, depth)
+    return await listPathFlat(this, key, path, dirs, depth)
   }
 
   /**

--- a/packages/buckets/src/buckets.ts
+++ b/packages/buckets/src/buckets.ts
@@ -46,7 +46,7 @@ const logger = log.getLogger('buckets')
  * const getOrInit = async (auth: UserAuth, bucketName: string) => {
  *   const buckets = Buckets.withUserAuth(auth)
  *   // Automatically scopes future calls to the Thread containing the bucket
- *   const { root, threadID } = await buckets.getOrInitBucket(bucketName)
+ *   const { root, threadID } = await buckets.getOrInit(bucketName)
  *   if (!root) throw new Error('bucket not created')
  *   const bucketKey = root.key
  *   return { buckets, bucketKey }
@@ -58,7 +58,7 @@ const logger = log.getLogger('buckets')
  * ```typescript
  * import { Buckets } from '@textile/hub'
  *
- * // This method requires that you run "open" or have specified "withThread"
+ * // This method requires that you run "getOrInit" or have specified "withThread"
  * async function logLinks (buckets: Buckets, bucketKey: string) {
  *   const links = await buckets.links(bucketKey)
  *   console.log(links)
@@ -114,7 +114,7 @@ export class Buckets extends BucketsGrpcClient {
    * @param threadName the name of the thread where the bucket is stored (default `buckets`)
    * @param isPrivate encrypt the bucket contents (default `false`)
    * @param threadID id of thread where bucket is stored
-   * @deprecated Open has been replaced with getOrInitBucket
+   * @deprecated Open has been replaced with getOrInit
    */
   async open(
     name: string,
@@ -122,7 +122,7 @@ export class Buckets extends BucketsGrpcClient {
     isPrivate = false,
     threadID?: string,
   ): Promise<{ root?: Root.AsObject; threadID?: string }> {
-    return this.getOrInitBucket(name, threadName, isPrivate, threadID)
+    return this.getOrInit(name, threadName, isPrivate, threadID)
   }
 
   /**
@@ -138,12 +138,12 @@ export class Buckets extends BucketsGrpcClient {
    *
    * const open = async (auth: UserAuth, name: string) => {
    *     const buckets = Buckets.withUserAuth(auth)
-   *     const { root, threadID } = await buckets.getOrInitBucket(name)
+   *     const { root, threadID } = await buckets.getOrInit(name)
    *     return { buckets, root, threadID }
    * }
    * ```
    */
-  async getOrInitBucket(
+  async getOrInit(
     name: string,
     threadName = 'buckets',
     isPrivate = false,

--- a/packages/buckets/src/buckets.ts
+++ b/packages/buckets/src/buckets.ts
@@ -268,6 +268,7 @@ export class Buckets extends BucketsGrpcClient {
    * listPathRecursive returns a nested object of all paths (and info) in a bucket
    * @param key Unique (IPNS compatible) identifier key for a bucket.
    * @param path A file/object (sub)-path within a bucket.
+   * @param dirs (optional) if false will include only file paths
    *
    * @example
    * ```typescript
@@ -288,9 +289,9 @@ export class Buckets extends BucketsGrpcClient {
    * // ]
    * ```
    */
-  async listPathRecursiveFlat(key: string, path: string): Promise<ListPathRecursiveFlat> {
+  async listPathRecursiveFlat(key: string, path: string, dirs = true): Promise<ListPathRecursiveFlat> {
     logger.debug('list path recursive request')
-    return await utilListPathRecursiveFlat(this, key, path)
+    return await utilListPathRecursiveFlat(this, key, path, dirs)
   }
 
   /**

--- a/packages/buckets/src/buckets.ts
+++ b/packages/buckets/src/buckets.ts
@@ -33,6 +33,7 @@ import {
   bucketsInit,
   PushPathResult,
 } from './api'
+import { utilListPathRecursive, utilListPathRecursiveFlat, ListPathRecursive, ListPathRecursiveFlat } from './utils'
 
 const logger = log.getLogger('buckets')
 
@@ -251,6 +252,45 @@ export class Buckets extends BucketsGrpcClient {
   async listPath(key: string, path: string): Promise<ListPathReply.AsObject> {
     logger.debug('list path request')
     return bucketsListPath(this, key, path)
+  }
+
+  /**
+   * Returns information about a bucket path.
+   * @param key Unique (IPNS compatible) identifier key for a bucket.
+   * @param path A file/object (sub)-path within a bucket.
+   */
+  async listPathRecursive(key: string, path: string): Promise<ListPathRecursive> {
+    logger.debug('list path recursive request')
+    return await utilListPathRecursive(this, key, path)
+  }
+
+  /**
+   * listPathRecursive returns a nested object of all paths (and info) in a bucket
+   * @param key Unique (IPNS compatible) identifier key for a bucket.
+   * @param path A file/object (sub)-path within a bucket.
+   *
+   * @example
+   * ```typescript
+   * import { Buckets } from '@textile/hub'
+   *
+   * async function printPaths(buckets: Buckets, bucketKey: string) {
+   *   const list = await buckets.listPathRecursiveFlat(bucketKey, '')
+   *   console.log(list)
+   * }
+   * // [
+   * //   'mybuck',
+   * //   'mybuck/.textileseed',
+   * //   'mybuck/dir1',
+   * //   'mybuck/dir1/file1.jpg',
+   * //   'mybuck/path',
+   * //   'mybuck/path/to',
+   * //   'mybuck/path/to/file2.jpg'
+   * // ]
+   * ```
+   */
+  async listPathRecursiveFlat(key: string, path: string): Promise<ListPathRecursiveFlat> {
+    logger.debug('list path recursive request')
+    return await utilListPathRecursiveFlat(this, key, path)
   }
 
   /**

--- a/packages/buckets/src/index.ts
+++ b/packages/buckets/src/index.ts
@@ -1,5 +1,7 @@
 export * from './api'
 export * from './buckets'
+export * from './utils'
+
 // Exports all API response types for typescript users
 export {
   Root,

--- a/packages/buckets/src/utils.ts
+++ b/packages/buckets/src/utils.ts
@@ -20,15 +20,21 @@ export type ListPathRecursive = ReturnType<typeof listPathRecursive>
 /**
  * listPathRecursive returns a nested object of all paths (and info) in a bucket
  */
-export async function listPathRecursive(grpc: BucketsGrpcClient, bucketKey: string, path: string) {
+export async function listPathRecursive(
+  grpc: BucketsGrpcClient,
+  bucketKey: string,
+  path: string,
+  depth: number,
+  currentDepth = 0,
+) {
   const rootPath = path === '' || path === '.' || path === '/' ? '' : `${path}/`
   const tree = await bucketsListPath(grpc, bucketKey, path)
-  if (tree.item) {
+  if (tree.item && (currentDepth + 1 <= depth || depth == -1)) {
     for (let i = 0; i < tree.item.itemsList.length; i++) {
       const obj = tree.item.itemsList[i]
       if (!obj.isdir) continue
       const dirPath = `${rootPath}${obj.name}`
-      const { item } = await listPathRecursive(grpc, bucketKey, dirPath)
+      const { item } = await listPathRecursive(grpc, bucketKey, dirPath, depth, currentDepth + 1)
       if (item) {
         tree.item.itemsList[i] = item
       }
@@ -37,14 +43,14 @@ export async function listPathRecursive(grpc: BucketsGrpcClient, bucketKey: stri
   return tree
 }
 
-async function treeToPaths(tree: ListPathItem.AsObject, path?: string, dirs = true): Promise<Array<string>> {
+async function treeToPaths(tree: ListPathItem.AsObject, path?: string, dirs = true, depth = 5): Promise<Array<string>> {
   const result = []
   const fp = path ? `${path}/${tree.name}` : `${tree.name}`
   // Only push if dirs included or not a dir
   if (dirs || !tree.isdir) result.push(fp)
   if (tree.isdir) {
     for (const item of tree.itemsList) {
-      const downtree = await treeToPaths(item, fp, dirs)
+      const downtree = await treeToPaths(item, fp, dirs, depth)
       result.push(...downtree)
     }
   }
@@ -56,8 +62,14 @@ export type ListPathRecursiveFlat = ReturnType<typeof listPathRecursiveFlat>
 /**
  * utilPathsList returns a string array of all paths in a bucket
  */
-export async function listPathRecursiveFlat(grpc: BucketsGrpcClient, bucketKey: string, path: string, dirs = true) {
-  const tree = await listPathRecursive(grpc, bucketKey, path)
+export async function listPathRecursiveFlat(
+  grpc: BucketsGrpcClient,
+  bucketKey: string,
+  path: string,
+  dirs: boolean,
+  depth: number,
+) {
+  const tree = await listPathRecursive(grpc, bucketKey, path, depth)
   if (!tree.item) return []
   return treeToPaths(tree.item, undefined, dirs)
 }

--- a/packages/buckets/src/utils.ts
+++ b/packages/buckets/src/utils.ts
@@ -57,12 +57,12 @@ async function treeToPaths(tree: ListPathItem.AsObject, path?: string, dirs = tr
   return result
 }
 
-export type ListPathRecursiveFlat = ReturnType<typeof listPathRecursiveFlat>
+export type ListPathFlat = ReturnType<typeof listPathFlat>
 
 /**
  * utilPathsList returns a string array of all paths in a bucket
  */
-export async function listPathRecursiveFlat(
+export async function listPathFlat(
   grpc: BucketsGrpcClient,
   bucketKey: string,
   path: string,

--- a/packages/buckets/src/utils.ts
+++ b/packages/buckets/src/utils.ts
@@ -1,12 +1,10 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
-import { Buffer } from 'buffer'
 import { ListPathItem, ListPathReply } from '@textile/buckets-grpc/buckets_pb'
 import { bucketsListPath, BucketsGrpcClient } from './api'
 /**
- * utilBufToArray converts a buffer into <4mb chunks for use with grpc API
- * @param chunk an input Buffer
+ * bytesToArray converts a buffer into <4mb chunks for use with grpc API
+ * @param chunk an input Buffer or Uint8Array
  */
-export function bufToArray(chunk: Buffer, size = 1024 * 1024 * 3) {
+export function bytesToArray(chunk: Uint8Array, size = 1024 * 1024 * 3) {
   const result = []
   const len = chunk.length
   let i = 0

--- a/packages/buckets/src/utils.ts
+++ b/packages/buckets/src/utils.ts
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import { Buffer } from 'buffer'
+import { ListPathItem, ListPathReply } from '@textile/buckets-grpc/buckets_pb'
+import { bucketsListPath, BucketsGrpcClient } from './api'
+/**
+ * utilBufToArray converts a buffer into <4mb chunks for use with grpc API
+ * @param chunk an input Buffer
+ */
+export function utilBufToArray(chunk: Buffer, size = 1024 * 1024 * 3) {
+  const result = []
+  const len = chunk.length
+  let i = 0
+  while (i < len) {
+    result.push(chunk.slice(i, (i += size)))
+  }
+  return result
+}
+
+export type ListPathRecursive = ReturnType<typeof utilListPathRecursive>
+/**
+ * listPathRecursive returns a nested object of all paths (and info) in a bucket
+ */
+export async function utilListPathRecursive(grpc: BucketsGrpcClient, bucketKey: string, path: string) {
+  const rootPath = path === '' || path === '.' || path === '/' ? '' : `${path}/`
+  const tree = await bucketsListPath(grpc, bucketKey, path)
+  const { item } = tree
+  if (item) {
+    for (let i = 0; i < item.itemsList.length; i++) {
+      const obj = item.itemsList[i]
+      if (!obj.isdir) continue
+      const dirPath = `${rootPath}${obj.name}`
+      const dir = await utilListPathRecursive(grpc, bucketKey, dirPath)
+      if (dir) {
+        item.itemsList[i] = dir
+      }
+    }
+  }
+  return item
+}
+
+async function treeToPaths(tree: ListPathItem.AsObject, path?: string, dirs = true): Promise<Array<string>> {
+  const result = []
+  const fp = path ? `${path}/${tree.name}` : `${tree.name}`
+  // Only push if dirs included or not a dir
+  if (dirs || !tree.isdir) result.push(fp)
+  if (tree.isdir) {
+    for (const item of tree.itemsList) {
+      const downtree = await treeToPaths(item, fp, dirs)
+      result.push(...downtree)
+    }
+  }
+  return result
+}
+
+export type ListPathRecursiveFlat = ReturnType<typeof utilListPathRecursiveFlat>
+
+/**
+ * utilPathsList returns a string array of all paths in a bucket
+ */
+export async function utilListPathRecursiveFlat(grpc: BucketsGrpcClient, bucketKey: string, path: string, dirs = true) {
+  const tree = await utilListPathRecursive(grpc, bucketKey, path)
+  if (!tree) return []
+  return treeToPaths(tree, undefined, dirs)
+}

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -24,7 +24,7 @@
       "hub.buckets.withuserauth",
       "hub.buckets.withkeyinfo",
       "hub.buckets.gettoken",
-      "hub.buckets.open",
+      "hub.buckets.getOrInitBucket",
       "hub.buckets.init",
       "hub.buckets.root",
       "hub.buckets.links",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -30,6 +30,7 @@
       "hub.buckets.links",
       "hub.buckets.list",
       "hub.buckets.listpath",
+      "hub.buckets.listPathFlat",
       "hub.buckets.listipfspath",
       "hub.buckets.pushpath",
       "hub.buckets.pullpath",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -24,7 +24,7 @@
       "hub.buckets.withuserauth",
       "hub.buckets.withkeyinfo",
       "hub.buckets.gettoken",
-      "hub.buckets.getOrInitBucket",
+      "hub.buckets.getOrInit",
       "hub.buckets.init",
       "hub.buckets.root",
       "hub.buckets.links",


### PR DESCRIPTION
will walk the full path tree and return a complete object or list of paths

e.g. 

```
     [
       'mybuck',
       'mybuck/.textileseed',
       'mybuck/dir1',
       'mybuck/dir1/file1.jpg',
       'mybuck/path',
       'mybuck/path/to',
       'mybuck/path/to/file2.jpg'
     ]
```