### PR TITLE
Expose date param for specifying auth timeout

### DIFF
--- a/packages/grpc-authentication/src/index.ts
+++ b/packages/grpc-authentication/src/index.ts
@@ -91,9 +91,9 @@ export class GrpcAuthentication extends GrpcConnection {
    * }
    * ```
    */
-  static async withKeyInfo(key: KeyInfo, host = defaultHost, debug = false) {
+  static async withKeyInfo(key: KeyInfo, host = defaultHost, debug = false, date?: Date) {
     const context = new Context(host)
-    await context.withKeyInfo(key)
+    await context.withKeyInfo(key, date)
     return new GrpcAuthentication(context, debug)
   }
 


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

## Description

This exposes the date parameter for the underlying Context's auth timeout directly in `withKeyInfo`. The parameter was added as a 3rd optional parameter to avoid breaking changes, though ideally in the future it would be moved forward or combined into an options arg.

Fixes #478. It would also benefit from https://github.com/textileio/js-threads/pull/525, though does not require it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Existing tests should continue to pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

> This PR template comes from https://github.com/embeddedartistry/templates
