### PR TITLE
chore(docs): only release docs on docs tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '@textile/hub@*.*.*'
+      - 'docs@*.*.*'
 jobs:
   deploy:
     name: Docs


### PR DESCRIPTION
With upcoming @next release, this just removes the automatic release of the docs landing pages on release tags. Instead, you can push a tag `docs@x.x.x` manually to trigger new docs updates. The automatic one was weirdly not consistent anyway.