### PR TITLE
Add ArchiveConfig API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2473,33 +2473,6 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
     },
-    "@types/to-json-schema": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@types/to-json-schema/-/to-json-schema-0.2.0.tgz",
-      "integrity": "sha512-9fqRjNFSSxJ8dQrE4v8gThS5ftxdFj8Q0y8hAjaF+uN+saJRxLiJdtFaDd9sv3bhzwcB2oDJpT/1ZelHnexbLw==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "*"
-      }
-    },
-    "@types/varint": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/varint/-/varint-5.0.0.tgz",
-      "integrity": "sha512-dIJiYqeDnYQ5Bc4mv+E5prqFIQlUTM1yDzwC5VQfL29pcYlm/5q1shY/MjbBT1FQAU5gzKE10DdGbu8B2EoFQg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/ws": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.6.tgz",
-      "integrity": "sha512-Q07IrQUSNpr+cXU4E4LtkSIBPie5GLZyyMC1QtQYRLWz701+XcoVygGUZgvLqElq1nU4ICldMYPnexlBsg3dqQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/yauzl": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
@@ -17591,6 +17564,12 @@
           }
         }
       }
+    },
+    "ws": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/packages/buckets/package-lock.json
+++ b/packages/buckets/package-lock.json
@@ -22,9 +22,9 @@
 			}
 		},
 		"@textile/buckets-grpc": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@textile/buckets-grpc/-/buckets-grpc-2.0.1.tgz",
-			"integrity": "sha512-H/1XzlMvYLbyP8fsjQmFkAJSv59pcfjCB3PfYwgcvZwq+LOlf8i62q06ZNei4CTbMSFKhe7mDgOWCGzJpHVrjQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@textile/buckets-grpc/-/buckets-grpc-2.1.0.tgz",
+			"integrity": "sha512-pfKgjSdFcskqYS3wY9IJIrvN8+aJ20rRlJSIXOL77zgea8KAVwLOSkcGiAFL9Sz8kALOMPUJt7wV3Ss/+FVFSQ==",
 			"requires": {
 				"@improbable-eng/grpc-web": "^0.13.0",
 				"@types/google-protobuf": "^3.7.3",

--- a/packages/buckets/package.json
+++ b/packages/buckets/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.13.0",
-    "@textile/buckets-grpc": "2.0.1",
+    "@textile/buckets-grpc": "2.1.0",
     "@textile/context": "^0.7.0",
     "@textile/crypto": "^0.1.1",
     "@textile/grpc-authentication": "^0.2.2",

--- a/packages/buckets/src/api/index.ts
+++ b/packages/buckets/src/api/index.ts
@@ -128,7 +128,7 @@ export type PathObject = {
  */
 export interface ArchiveConfig {
   /**
-   * RepFactor indicates the desired amount of active deals
+   * RepFactor (ignored in Filecoin testnet) indicates the desired amount of active deals
    * with different miners to store the data. While making deals
    * the other attributes of FilConfig are considered for miner selection.
    */
@@ -138,17 +138,17 @@ export interface ArchiveConfig {
    */
   dealMinDuration: number
   /**
-   * ExcludedMiners is a set of miner addresses won't be ever be selected
+   * ExcludedMiners (ignored in Filecoin testnet) is a set of miner addresses won't be ever be selected
    *when making new deals, even if they comply to other filters.
    */
   excludedMiners: Array<string>
   /**
-   * TrustedMiners is a set of miner addresses which will be forcibly used
+   * TrustedMiners (ignored in Filecoin testnet) is a set of miner addresses which will be forcibly used
    * when making new deals. An empty/nil list disables this feature.
    */
   trustedMiners: Array<string>
   /**
-   * CountryCodes indicates that new deals should select miners on specific countries.
+   * CountryCodes (ignored in Filecoin testnet) indicates that new deals should select miners on specific countries.
    */
   countryCodes: Array<string>
   /**

--- a/packages/buckets/src/api/index.ts
+++ b/packages/buckets/src/api/index.ts
@@ -1,7 +1,9 @@
 import { grpc } from '@improbable-eng/grpc-web'
 import {
+  ArchiveConfig as ProtoArchiveConfig,
   ArchiveInfoRequest,
   ArchiveInfoResponse,
+  ArchiveRenew as ProtoArchiveRenew,
   ArchiveRequest,
   ArchiveStatusRequest,
   ArchiveStatusResponse,
@@ -9,6 +11,8 @@ import {
   ArchiveWatchResponse,
   CreateRequest,
   CreateResponse,
+  DefaultArchiveConfigRequest,
+  DefaultArchiveConfigResponse,
   LinksRequest,
   LinksResponse,
   ListIpfsPathRequest,
@@ -33,6 +37,7 @@ import {
   Root,
   RootRequest,
   RootResponse,
+  SetDefaultArchiveConfigRequest,
   SetPathRequest,
 } from '@textile/buckets-grpc/buckets_pb'
 import { APIService, APIServicePushPath } from '@textile/buckets-grpc/buckets_pb_service'
@@ -116,6 +121,118 @@ export type PathItemObject = {
 export type PathObject = {
   item?: PathItemObject
   root?: RootObject
+}
+
+/**
+ * ArchiveConfig is the desired state of a Cid in the Filecoin network.
+ */
+export interface ArchiveConfig {
+  /**
+   * RepFactor indicates the desired amount of active deals
+   * with different miners to store the data. While making deals
+   * the other attributes of FilConfig are considered for miner selection.
+   */
+  repFactor: number
+  /**
+   * DealMinDuration indicates the duration to be used when making new deals.
+   */
+  dealMinDuration: number
+  /**
+   * ExcludedMiners is a set of miner addresses won't be ever be selected
+   *when making new deals, even if they comply to other filters.
+   */
+  excludedMiners: Array<string>
+  /**
+   * TrustedMiners is a set of miner addresses which will be forcibly used
+   * when making new deals. An empty/nil list disables this feature.
+   */
+  trustedMiners: Array<string>
+  /**
+   * CountryCodes indicates that new deals should select miners on specific countries.
+   */
+  countryCodes: Array<string>
+  /**
+   * Renew indicates deal-renewal configuration.
+   */
+  renew?: ArchiveRenew
+  /**
+   * Addr is the wallet address used to store the data in filecoin
+   */
+  addr: string
+  /**
+   * MaxPrice is the maximum price that will be spent to store the data, 0 is no max
+   */
+  maxPrice: number
+  /**
+   *
+   * FastRetrieval indicates that created deals should enable the
+   * fast retrieval feature.
+   */
+  fastRetrieval: boolean
+  /**
+   * DealStartOffset indicates how many epochs in the future impose a
+   * deadline to new deals being active on-chain. This value might influence
+   * if miners accept deals, since they should seal fast enough to satisfy
+   * this constraint.
+   */
+  dealStartOffset: number
+}
+
+/**
+ * ArchiveRenew contains renew configuration for a ArchiveConfig.
+ */
+export interface ArchiveRenew {
+  /**
+   * Enabled indicates that deal-renewal is enabled for this Cid.
+   */
+  enabled: boolean
+  /**
+   * Threshold indicates how many epochs before expiring should trigger
+   * deal renewal. e.g: 100 epoch before expiring.
+   */
+  threshold: number
+}
+
+const fromProtoArchiveConfig = (protoConfig: ProtoArchiveConfig): ArchiveConfig => {
+  const config: ArchiveConfig = {
+    addr: protoConfig.getAddr(),
+    countryCodes: protoConfig.getCountryCodesList(),
+    dealMinDuration: protoConfig.getDealMinDuration(),
+    dealStartOffset: protoConfig.getDealStartOffset(),
+    excludedMiners: protoConfig.getExcludedMinersList(),
+    fastRetrieval: protoConfig.getFastRetrieval(),
+    maxPrice: protoConfig.getMaxPrice(),
+    repFactor: protoConfig.getRepFactor(),
+    trustedMiners: protoConfig.getTrustedMinersList(),
+  }
+  const renew = protoConfig.getRenew()
+  if (renew) {
+    config.renew = {
+      enabled: renew.getEnabled(),
+      threshold: renew.getThreshold(),
+    }
+  }
+  return config
+}
+
+const toProtoArchiveConfig = (config: ArchiveConfig): ProtoArchiveConfig => {
+  const protoConfig = new ProtoArchiveConfig()
+  protoConfig.setAddr(config.addr)
+  protoConfig.setCountryCodesList(config.countryCodes)
+  protoConfig.setDealMinDuration(config.dealMinDuration)
+  protoConfig.setDealStartOffset(config.dealStartOffset)
+  protoConfig.setExcludedMinersList(config.excludedMiners)
+  protoConfig.setFastRetrieval(config.fastRetrieval)
+  protoConfig.setMaxPrice(config.maxPrice)
+  protoConfig.setRepFactor(config.repFactor)
+  protoConfig.setTrustedMinersList(config.trustedMiners)
+  if (config.renew) {
+    const renew = new ProtoArchiveRenew()
+    renew.setEnabled(config.renew.enabled)
+    renew.setThreshold(config.renew.threshold)
+    protoConfig.setRenew(renew)
+  }
+  return protoConfig
 }
 
 /**
@@ -659,14 +776,64 @@ export async function bucketsPullPathAccessRoles(
 }
 
 /**
+ * @internal
+ */
+export async function bucketsDefaultArchiveConfig(api: GrpcConnection, key: string, ctx?: ContextInterface) {
+  logger.debug('default archive config request')
+  const req = new DefaultArchiveConfigRequest()
+  req.setKey(key)
+  const res: DefaultArchiveConfigResponse = await api.unary(APIService.DefaultArchiveConfig, req, ctx)
+  const config = res.getArchiveConfig()
+  if (!config) {
+    throw new Error('no archive config returned')
+  }
+  return fromProtoArchiveConfig(config)
+}
+
+/**
+ * @internal
+ */
+export async function bucketsSetDefaultArchiveConfig(
+  api: GrpcConnection,
+  key: string,
+  config: ArchiveConfig,
+  ctx?: ContextInterface,
+) {
+  logger.debug('set default archive config request')
+  const req = new SetDefaultArchiveConfigRequest()
+  req.setKey(key)
+  req.setArchiveConfig(toProtoArchiveConfig(config))
+  await api.unary(APIService.SetDefaultArchiveConfig, req, ctx)
+  return
+}
+/**
+ * An object to configure options for Archive.
+ */
+export interface ArchiveOptions {
+  /**
+   * Provide a custom ArchiveConfig to override use of the default.
+   */
+  archiveConfig?: ArchiveConfig
+}
+
+/**
  * archive creates a Filecoin bucket archive via Powergate.
  * @internal
  * @param key Unique (IPNS compatible) identifier key for a bucket.
+ * @param options Options that control the behavior of the bucket archive
  */
-export async function bucketsArchive(api: GrpcConnection, key: string, ctx?: ContextInterface) {
+export async function bucketsArchive(
+  api: GrpcConnection,
+  key: string,
+  options?: ArchiveOptions,
+  ctx?: ContextInterface,
+) {
   logger.debug('archive request')
   const req = new ArchiveRequest()
   req.setKey(key)
+  if (options?.archiveConfig) {
+    req.setArchiveConfig(toProtoArchiveConfig(options.archiveConfig))
+  }
   await api.unary(APIService.Archive, req, ctx)
   return
 }

--- a/packages/buckets/src/buckets.ts
+++ b/packages/buckets/src/buckets.ts
@@ -10,13 +10,16 @@ import { KeyInfo, UserAuth } from '@textile/security'
 import { ThreadID } from '@textile/threads-id'
 import log from 'loglevel'
 import {
+  ArchiveConfig,
   ArchiveInfo,
+  ArchiveOptions,
   ArchiveStatus,
   bucketsArchive,
   bucketsArchiveInfo,
   bucketsArchiveStatus,
   bucketsArchiveWatch,
   bucketsCreate,
+  bucketsDefaultArchiveConfig,
   bucketsLinks,
   bucketsList,
   bucketsListIpfsPath,
@@ -28,6 +31,7 @@ import {
   bucketsRemove,
   bucketsRemovePath,
   bucketsRoot,
+  bucketsSetDefaultArchiveConfig,
   bucketsSetPath,
   CreateObject,
   LinksObject,
@@ -649,7 +653,6 @@ export class Buckets extends GrpcAuthentication {
    *    buckets.pushPathAccessRoles(key, '/', roles)
    * }
    * ```
-   * 
    * @example
    * Grant read access to everyone at a path (in an encrypted bucket)
    * ```typescript
@@ -690,6 +693,50 @@ export class Buckets extends GrpcAuthentication {
   }
 
   /**
+   * (Experimental) Get the current default ArchiveConfig for the specified Bucket.
+   *
+   * @beta
+   * @param key Unique (IPNS compatible) identifier key for a bucket.
+   * @returns The default ArchiveConfig for the specified Bucket.
+   *
+   * @example
+   * Get the default ArchiveConfig
+   * ```typescript
+   * import { Buckets } from '@textile/hub'
+   *
+   * async function getDefaultConfig (buckets: Buckets, key: string) {
+   *    const defaultConfig = await buckets.defaultArchiveConfig(key)
+   * }
+   * ```
+   */
+  async defaultArchiveConfig(key: string) {
+    logger.debug('default archive config request')
+    return bucketsDefaultArchiveConfig(this, key)
+  }
+
+  /**
+   * (Experimental) Set the default ArchiveConfig for the specified Bucket.
+   *
+   * @beta
+   * @param key Unique (IPNS compatible) identifier key for a bucket.
+   * @param config The ArchiveConfig to set as the new default.
+   *
+   * @example
+   * Set the default ArchiveConfig
+   * ```typescript
+   * import { Buckets } from '@textile/hub'
+   *
+   * async function getDefaultConfig (buckets: Buckets, key: string, config: ArchiveConfig) {
+   *    await buckets.defaultArchiveConfig(key, config)
+   * }
+   * ```
+   */
+  async setDefaultArchiveConfig(key: string, config: ArchiveConfig) {
+    logger.debug('set default archive config request')
+    return bucketsSetDefaultArchiveConfig(this, key, config)
+  }
+
+  /**
    * (Experimental) Store a snapshot of the bucket on Filecoin.
    * @remarks
    * Filecoin support is experimental. By using Textile, you
@@ -699,6 +746,7 @@ export class Buckets extends GrpcAuthentication {
    *
    * @beta
    * @param key Unique (IPNS compatible) identifier key for a bucket.
+   * @param options An object to set options that control the behavor of archive.
    *
    * @example
    * Remove a file by its relative path
@@ -706,13 +754,13 @@ export class Buckets extends GrpcAuthentication {
    * import { Buckets } from '@textile/hub'
    *
    * async function archive (buckets: Buckets, key: string) {
-   *    buckets.archive(key)
+   *    await buckets.archive(key)
    * }
    * ```
    */
-  async archive(key: string) {
+  async archive(key: string, options?: ArchiveOptions) {
     logger.debug('archive request')
-    return bucketsArchive(this, key)
+    return bucketsArchive(this, key, options)
   }
 
   /**

--- a/packages/buckets/src/buckets.ts
+++ b/packages/buckets/src/buckets.ts
@@ -724,10 +724,10 @@ export class Buckets extends GrpcAuthentication {
    * @example
    * Set the default ArchiveConfig
    * ```typescript
-   * import { Buckets } from '@textile/hub'
+   * import { Buckets, ArchiveConfig } from '@textile/hub'
    *
-   * async function getDefaultConfig (buckets: Buckets, key: string, config: ArchiveConfig) {
-   *    await buckets.defaultArchiveConfig(key, config)
+   * async function setDefaultConfig (buckets: Buckets, key: string, config: ArchiveConfig) {
+   *    await buckets.setDefaultArchiveConfig(key, config)
    * }
    * ```
    */


### PR DESCRIPTION
Adds client API for getting the default Bucket `ArchiveConfig`, setting a new default `ArchiveConfig`, and providing a custom `ArchiveConfig` to any call to `archive()`.

Here's what an `ArchiveConfig` looks like (it's basically a Powergate FFS `FilConfig`):
```
export interface ArchiveConfig {
  /**
   * RepFactor indicates the desired amount of active deals
   * with different miners to store the data. While making deals
   * the other attributes of FilConfig are considered for miner selection.
   */
  repFactor: number
  /**
   * DealMinDuration indicates the duration to be used when making new deals.
   */
  dealMinDuration: number
  /**
   * ExcludedMiners is a set of miner addresses won't be ever be selected
   *when making new deals, even if they comply to other filters.
   */
  excludedMiners: Array<string>
  /**
   * TrustedMiners is a set of miner addresses which will be forcibly used
   * when making new deals. An empty/nil list disables this feature.
   */
  trustedMiners: Array<string>
  /**
   * CountryCodes indicates that new deals should select miners on specific countries.
   */
  countryCodes: Array<string>
  /**
   * Renew indicates deal-renewal configuration.
   */
  renew?: ArchiveRenew
  /**
   * Addr is the wallet address used to store the data in filecoin
   */
  addr: string
  /**
   * MaxPrice is the maximum price that will be spent to store the data, 0 is no max
   */
  maxPrice: number
  /**
   *
   * FastRetrieval indicates that created deals should enable the
   * fast retrieval feature.
   */
  fastRetrieval: boolean
  /**
   * DealStartOffset indicates how many epochs in the future impose a
   * deadline to new deals being active on-chain. This value might influence
   * if miners accept deals, since they should seal fast enough to satisfy
   * this constraint.
   */
  dealStartOffset: number
}

/**
 * ArchiveRenew contains renew configuration for a ArchiveConfig.
 */
export interface ArchiveRenew {
  /**
   * Enabled indicates that deal-renewal is enabled for this Cid.
   */
  enabled: boolean
  /**
   * Threshold indicates how many epochs before expiring should trigger
   * deal renewal. e.g: 100 epoch before expiring.
   */
  threshold: number
}
```